### PR TITLE
Addition of isProduction method and property

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -9,9 +9,12 @@ class Client {
 
     protected $client;
 
+    private $isProduction;
+
     public function __construct($config = [])
     {
         $this->config = $config;
+        $this->isProduction = FALSE;
 
         $this->client = new GuzzleClient([
             'base_url' => 'https://api.stathat.com/',
@@ -36,6 +39,7 @@ class Client {
     public function count($stat_key, $count = 1)
     {
         if(!isset($this->config['user_key'])) throw new Exception('StatHat user key not set.');
+        if($this->isProduction == FALSE) return;
 
         return $this->client->post('c', ['body' => ['ukey' => $this->config['user_key'], 'key' => $stat_key, 'count' => $count]]);
     }
@@ -52,6 +56,7 @@ class Client {
     public function value($stat_key, $value)
     {
         if(!isset($this->config['user_key'])) throw new Exception('StatHat user key not set.');
+        if($this->isProduction == FALSE) return;
 
         return $this->client->post('v', ['body' => ['ukey' => $this->config['user_key'], 'key' => $stat_key, 'value' => $value]]);
     }
@@ -68,6 +73,7 @@ class Client {
     public function ezCount($stat, $count = 1)
     {
         if(!isset($this->config['ez_key'])) throw new Exception('StatHat EZ key not set.');
+        if($this->isProduction == FALSE) return;
 
         return $this->client->post('ez', ['body' => ['ezkey' => $this->config['ez_key'], 'stat' => $stat, 'count' => $count]]);
     }
@@ -84,8 +90,19 @@ class Client {
     public function ezValue($stat, $value)
     {
         if(!isset($this->config['ez_key'])) throw new Exception('StatHat EZ key not set.');
+        if($this->isProduction == FALSE) return;
 
         return $this->client->post('ez', ['body' => ['ezkey' => $this->config['ez_key'], 'stat' => $stat, 'value' => $value]]);
+    }
+
+    /**
+     * Enable and disable StatHat collection as a general setting.
+     *
+     * @param $isProduction boolean - Flag to toggle stat collection
+     */
+    public function isProduction($enable = FALSE)
+    {
+        $this->isProduction = $enable;
     }
 
 }


### PR DESCRIPTION
Fixes #1 

Adds `isProduction` property and method to allow enabling / disabling reporting of stats to StatHat. The idea is to toggle the value between development and production environments to prevent reporting stats when working on applications that use this library.
