### PR TITLE
Adds enable config setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ In vanilla PHP, simply require the `Client` class and create a new instance with
   use DoSomething\StatHat\Client as StatHat;
   
   $stathat = new StatHat([
-    'enabled' => (getenv('APP_ENV') == 'production'),
     'ez_key' => '...',
-    'user_key' => '...'
+    'user_key' => '...',
+    'debug' => (getenv('APP_ENV') != 'production')
   ]);
   $stathat->ezCount('stat_name', 1);
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@ In vanilla PHP, simply require the `Client` class and create a new instance with
 ```php
   use DoSomething\StatHat\Client as StatHat;
   
-  $stathat = new StatHat(['ez_key' => '...', 'user_key' => '...']);
+  $stathat = new StatHat([
+    'enabled' => (getenv('APP_ENV') == 'production'),
+    'ez_key' => '...',
+    'user_key' => '...'
+  ]);
   $stathat->ezCount('stat_name', 1);
 ```
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -36,7 +36,7 @@ class Client {
     public function count($stat_key, $count = 1)
     {
         if(!isset($this->config['user_key'])) throw new Exception('StatHat user key not set.');
-        if($this->config['enabled'] == FALSE) return;
+        if($this->config['debug']) return;
 
         return $this->client->post('c', ['body' => ['ukey' => $this->config['user_key'], 'key' => $stat_key, 'count' => $count]]);
     }
@@ -53,7 +53,7 @@ class Client {
     public function value($stat_key, $value)
     {
         if(!isset($this->config['user_key'])) throw new Exception('StatHat user key not set.');
-        if($this->config['enabled'] == FALSE) return;
+        if($this->config['debug']) return;
 
         return $this->client->post('v', ['body' => ['ukey' => $this->config['user_key'], 'key' => $stat_key, 'value' => $value]]);
     }
@@ -70,7 +70,7 @@ class Client {
     public function ezCount($stat, $count = 1)
     {
         if(!isset($this->config['ez_key'])) throw new Exception('StatHat EZ key not set.');
-        if($this->config['enabled'] == FALSE) return;
+        if($this->config['debug']) return;
 
         return $this->client->post('ez', ['body' => ['ezkey' => $this->config['ez_key'], 'stat' => $stat, 'count' => $count]]);
     }
@@ -87,7 +87,7 @@ class Client {
     public function ezValue($stat, $value)
     {
         if(!isset($this->config['ez_key'])) throw new Exception('StatHat EZ key not set.');
-        if($this->config['enabled'] == FALSE) return;
+        if($this->config['debug']) return;
 
         return $this->client->post('ez', ['body' => ['ezkey' => $this->config['ez_key'], 'stat' => $stat, 'value' => $value]]);
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -36,6 +36,7 @@ class Client {
     public function count($stat_key, $count = 1)
     {
         if(!isset($this->config['user_key'])) throw new Exception('StatHat user key not set.');
+        if($this->config['enabled'] == FALSE) return;
 
         return $this->client->post('c', ['body' => ['ukey' => $this->config['user_key'], 'key' => $stat_key, 'count' => $count]]);
     }
@@ -52,6 +53,7 @@ class Client {
     public function value($stat_key, $value)
     {
         if(!isset($this->config['user_key'])) throw new Exception('StatHat user key not set.');
+        if($this->config['enabled'] == FALSE) return;
 
         return $this->client->post('v', ['body' => ['ukey' => $this->config['user_key'], 'key' => $stat_key, 'value' => $value]]);
     }
@@ -68,6 +70,7 @@ class Client {
     public function ezCount($stat, $count = 1)
     {
         if(!isset($this->config['ez_key'])) throw new Exception('StatHat EZ key not set.');
+        if($this->config['enabled'] == FALSE) return;
 
         return $this->client->post('ez', ['body' => ['ezkey' => $this->config['ez_key'], 'stat' => $stat, 'count' => $count]]);
     }
@@ -84,6 +87,7 @@ class Client {
     public function ezValue($stat, $value)
     {
         if(!isset($this->config['ez_key'])) throw new Exception('StatHat EZ key not set.');
+        if($this->config['enabled'] == FALSE) return;
 
         return $this->client->post('ez', ['body' => ['ezkey' => $this->config['ez_key'], 'stat' => $stat, 'value' => $value]]);
     }


### PR DESCRIPTION
Based on comment by @DFurnes : https://github.com/DoSomething/stathat-php/pull/2#issuecomment-106424045
- Adds `'enabled' => (getenv('APP_ENV') == 'production')` to config settings.

Use this setting to toggle reporting stats from dev to production.
