### PR TITLE
Fixes issue with broken HTTP requests.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -127,11 +127,11 @@ class Client
 
         // Y'know back in my day we had to write our HTTP requests by
         // hand, and uphill both ways. Now these kids with their Guzzles...
-        $out = 'POST '.$parts['path'].' HTTP/1.1\r\n';
-        $out .= 'Host: '.$parts['host'].'\r\n';
-        $out .= 'Content-Type: application/x-www-form-urlencoded\r\n';
-        $out .= 'Content-Length: '.strlen($contents).'\r\n';
-        $out .= 'Connection: Close\r\n\r\n';
+        $out = 'POST '.$parts['path'].' HTTP/1.1'."\r\n";
+        $out .= 'Host: '.$parts['host']."\r\n";
+        $out .= 'Content-Type: application/x-www-form-urlencoded'."\r\n";
+        $out .= 'Content-Length: '.strlen($contents)."\r\n";
+        $out .= 'Connection: Close'."\r\n\r\n";
         if (isset($contents)) {
             $out .= $contents;
         }


### PR DESCRIPTION
#### Changes

Fixes issue where HTTP requests to StatHat were not being made because the `\n\r` end-of-line escape characters in the request were being ignored by PHP. Changing those into double-quoted strings fixes everything up.
#### Nerdy Context

PHP doesn't interpret a bunch of escape sequences [in single-quoted strings](http://php.net/manual/en/language.types.string.php). There's a constant (`PHP_EOL`) for `"\n"` built in to PHP, but nothing for `"\r"` which is [part of the required formatting for raw HTTP requests](http://stackoverflow.com/a/5757349/811624).

---

For review: @angaither @weerd 
