### PR TITLE
First pass at curlGet()

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -123,7 +123,7 @@ class Client
 
         return $result;
     }
-    
+
     /**
      * Get listing of all stat alerts using the Alerts API.
      *
@@ -234,9 +234,10 @@ class Client
      */
     private function curlDelete($curl_url)
     {
+
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $curl_url);
-        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "DELETE");
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         $result = curl_exec($ch);
         $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
@@ -244,10 +245,9 @@ class Client
 
         if ($http_code == 404) {
             $result = $http_code;
-        }
-        else {
+        } else {
             $json_result = json_decode($result);
-            $result = $http_code . ': ' . $json_result->msg;
+            $result = $http_code.': '.$json_result->msg;
         }
 
         return $result;

--- a/src/Client.php
+++ b/src/Client.php
@@ -134,7 +134,7 @@ class Client
         if (! isset($this->config['access_token'])) {
             throw new Exception('StatHat Alerts API Access Token not set.');
         }
-        $result = $this->curlGet($this->alerts_url.'x/'.$this->config['access_token'].'/alerts');
+        $result = $this->curlGet($this->alerts_url.'/x/'.$this->config['access_token'].'/alerts');
 
         return $result;
     }
@@ -151,7 +151,7 @@ class Client
         if (! isset($this->config['access_token'])) {
             throw new Exception('StatHat Alerts API Access Token not set.');
         }
-        $result = $this->curlDelete($this->alerts_url.'x/'.$this->config['access_token'].'/alerts/'.$alert_id);
+        $result = $this->curlDelete($this->alerts_url.'/x/'.$this->config['access_token'].'/alerts/'.$alert_id);
         
         return $result;
     }
@@ -226,26 +226,28 @@ class Client
      * Perform cURL DELETE request to route. For example used by
      * Alerts API requests: https://www.stathat.com/manual/alerts_api
      *
-     * @param string $curlURL
+     * @param string $curl_url
      *   Ex: /x/ACCESSTOKEN/alerts/ALERTID
      * @return string $result
      *   Response code.
      */
-    private function curlDelete($curlURL)
+    private function curlDelete($curl_url)
     {
-        
         $ch = curl_init();
-        curl_setopt($ch, CURLOPT_URL, $curlUrl);
+        curl_setopt($ch, CURLOPT_URL, $curl_url);
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "DELETE");
-        curl_setopt($ch, CURLOPT_HEADER, TRUE);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, array(
-          'Accept: application/json',
-          'Content-Type: application/json',
-        ));
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-        curl_exec($ch);
-        $result = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        $result = curl_exec($ch);
+        $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         curl_close($ch);
+
+        if ($http_code == 404) {
+          $result = $http_code;
+        }
+        else {
+          $json_result = json_decode($result);
+          $result = $http_code . ': ' . $json_result->msg;
+        }
 
         return $result;
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -196,16 +196,16 @@ class Client
      * Perform cURL GET request to route. For example used by
      * Alerts API requests: https://www.stathat.com/manual/alerts_api
      *
-     * @param string $curlURL
+     * @param string $curl_url
      *   Ex: https://www.stathat.com/x/ACCESSTOKEN/alerts
      * @return array or string $result
      *   An array of alert details or the response code string in the case of a non 200 response.
      */
-    private function curlGet($curlURL)
+    private function curlGet($curl_url)
     {
 
         $ch = curl_init();
-        curl_setopt($ch, CURLOPT_URL, $curlUrl);
+        curl_setopt($ch, CURLOPT_URL, $curl_url);
         curl_setopt($ch, CURLOPT_HTTPHEADER, array(
           'Accept: application/json',
           'Content-Type: application/json',

--- a/src/Client.php
+++ b/src/Client.php
@@ -204,7 +204,6 @@ class Client
      */
     private function curlGet($curl_url)
     {
-
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $curl_url);
         curl_setopt($ch, CURLOPT_HTTPHEADER, [
@@ -234,7 +233,6 @@ class Client
      */
     private function curlDelete($curl_url)
     {
-
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $curl_url);
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');

--- a/src/Client.php
+++ b/src/Client.php
@@ -231,7 +231,7 @@ class Client
      *
      * @param string $curl_url
      *   Ex: /x/ACCESSTOKEN/alerts/ALERTID
-     * @return boolean
+     * @return bool
      *   Response code.
      */
     private function curlDelete($curl_url)

--- a/src/Client.php
+++ b/src/Client.php
@@ -120,6 +120,7 @@ class Client
         }
 
         $result = $this->deleteAlertCurl('x/'.$this->config['access_token'].'/alerts/'.$alert_id);
+
         return $result;
     }
     
@@ -152,7 +153,7 @@ class Client
             throw new Exception('StatHat Alerts API Access Token not set.');
         }
         $result = $this->curlDelete($this->alerts_url.'/x/'.$this->config['access_token'].'/alerts/'.$alert_id);
-        
+
         return $result;
     }
 
@@ -206,16 +207,16 @@ class Client
 
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $curl_url);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
           'Accept: application/json',
           'Content-Type: application/json',
-        ));
+        ]);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         $jsonResult = curl_exec($ch);
         $result = json_decode($jsonResult);
         $responseCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         if ($responseCode != 200) {
-          $result = $responseCode;
+            $result = $responseCode;
         }
         curl_close($ch);
 
@@ -242,11 +243,11 @@ class Client
         curl_close($ch);
 
         if ($http_code == 404) {
-          $result = $http_code;
+            $result = $http_code;
         }
         else {
-          $json_result = json_decode($result);
-          $result = $http_code . ': ' . $json_result->msg;
+            $json_result = json_decode($result);
+            $result = $http_code . ': ' . $json_result->msg;
         }
 
         return $result;


### PR DESCRIPTION
Fixes #10 

Add support for `StatHat Alerts API` to list all alerts. Needed to get alert IDs for `DELETE` requests.
https://www.stathat.com/manual/alerts_api
- **List all alerts**: Get a list of all your manual alerts.

```
https://www.stathat.com/x/ACCESSTOKEN/alerts
```

**Example reply**:

```
[{
        "id":"XXXX",
        "stat_id":"AAAA",
        "stat_name": "api call",
        "kind": "data",
        "time_window": "5m",
},
{
        "id": "YYYY",
        "stat_id":"BBBB",
        "stat_name":"overall http request time",
        "kind": "value",
        "time_window": "1h",
        "operator": "greater than",
        "threshold": 500
},
{
        "id": "ZZZZ",
        "stat_id":"CCCC",
        "stat_name":"number of paid users",
        "kind": "value",
        "time_window": "1d",
        "operator": "greater than",
        "threshold": 1000
}]
```
